### PR TITLE
Add history of object creation when user POSTs form

### DIFF
--- a/mapper/tests.py
+++ b/mapper/tests.py
@@ -9,6 +9,7 @@ from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
+import json
 import responses
 
 from .models import MigrateSubscription
@@ -335,4 +336,9 @@ class CreateSubscriptionMigrationFormTests(TestCase):
         [history] = LogEntry.objects.filter(object_id=migration.pk)
         self.assertEqual(history.user, user)
         self.assertEqual(history.action_flag, ADDITION)
-        self.assertEqual(history.change_message, "Added.")
+        self.assertEqual(json.loads(history.change_message), [{
+            'added': {
+                'object': str(migration),
+                'name': str(migration._meta.verbose_name),
+            }
+        }])

--- a/mapper/tests.py
+++ b/mapper/tests.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 
 from django.db import connections
 from django.conf import settings
+from django.contrib.admin.models import LogEntry, ADDITION
 from django.contrib.auth.models import User
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.test import TestCase
@@ -312,7 +313,8 @@ class CreateSubscriptionMigrationFormTests(TestCase):
             for table, columns in tables.items():
                 columns = ','.join(('{} TEXT'.format(c) for c in columns))
                 cursor.execute("CREATE TABLE {}({})".format(table, columns))
-        self.client.force_login(User.objects.create_user('testuser'))
+        user = User.objects.create_user('testuser')
+        self.client.force_login(user)
 
         response = self.client.post(reverse('migration-list'), data={
             'table_name': 'testtable1',
@@ -323,7 +325,14 @@ class CreateSubscriptionMigrationFormTests(TestCase):
         self.assertRedirects(response, reverse('migration-list'))
 
         [migration] = MigrateSubscription.objects.all()
+        # Test object is created correctly
         self.assertEqual(migration.table_name, 'testtable1')
         self.assertEqual(migration.column_name, tables['testtable1'][0])
         self.assertEqual(migration.from_messageset, 1)
         self.assertEqual(migration.to_messageset, 2)
+
+        # Test object history is created correctly
+        [history] = LogEntry.objects.filter(object_id=migration.pk)
+        self.assertEqual(history.user, user)
+        self.assertEqual(history.action_flag, ADDITION)
+        self.assertEqual(history.change_message, "Added.")

--- a/mapper/views.py
+++ b/mapper/views.py
@@ -128,6 +128,14 @@ class MigrateSubscriptionListView(
             object_id=self.object.pk,
             object_repr=force_text(self.object),
             action_flag=ADDITION,
-            change_message='Added.'
+            # From django.contrib.admin.utils.construct_change_message
+            change_message=[
+                {
+                    'added': {
+                        'name': str(self.object._meta.verbose_name),
+                        'object': str(self.object)
+                    }
+                }
+            ]
         )
         return redirect


### PR DESCRIPTION
We will want to have a history of all the actions taken on a migration, as well as who took those actions. We can use django admin's built in LogEntry system to do this, that way the actions will show up in the django admin