### PR TITLE
Allow resuming errored migrations

### DIFF
--- a/mapper/tasks.py
+++ b/mapper/tasks.py
@@ -36,8 +36,10 @@ class MigrateSubscriptionsTask(Task):
         Returns a string which represents the SQL query to fetch all of the
         identities.
         """
-        return 'SELECT {column} FROM {table}'.format(
-            column=migrate.column_name, table=migrate.table_name)
+        return 'SELECT {column} FROM {table} ORDER BY {column} OFFSET {count}'\
+            .format(
+                column=migrate.column_name, table=migrate.table_name,
+                count=migrate.current)
 
     def fetch_identities(self, migrate):
         """

--- a/mapper/templates/mapper/migratesubscription_list.html
+++ b/mapper/templates/mapper/migratesubscription_list.html
@@ -31,6 +31,12 @@
                     <td>{{ migration.get_status_display }} {{ migration.current }}/{% if migration.total %}{{ migration.total }}{% else %}-{% endif %}</td>
                     <td>
                         {# TODO: Add action buttons here #}
+                        {% if migration.status == 'E' %}
+                        <form action="{% url 'migration-retry' migration_id=migration.pk %}" method="post">
+                            {% csrf_token %}
+                            <button type="submit">Retry</button>
+                        </form>
+                        {% endif %}
                         <a href="{% url 'log-list' migration_id=migration.pk %}">Logs</a>
                     </td>
                 </tr>

--- a/mapper/tests.py
+++ b/mapper/tests.py
@@ -546,7 +546,7 @@ class MigrateSubscriptionsTaskTest(TestCase):
         with self.assertNumQueries(6, using='identities'):
             identities = sorted(
                 migrate_subscriptions.fetch_identities(migrate))
-        self.assertEqual(identities, range(20))
+        self.assertEqual(identities, list(range(20)))
 
     def test_fetch_identities_with_offset(self):
         """
@@ -567,7 +567,7 @@ class MigrateSubscriptionsTaskTest(TestCase):
 
         identities = sorted(
             migrate_subscriptions.fetch_identities(migrate))
-        self.assertEqual(identities, range(10, 20))
+        self.assertEqual(identities, list(range(10, 20)))
 
     @mock.patch('mapper.tasks.MigrateSubscriptionsTask.migrate_identity')
     @mock.patch('mapper.tasks.MigrateSubscriptionsTask.fetch_identities')

--- a/mapper/urls.py
+++ b/mapper/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
-from .views import LogListView, MigrateSubscriptionListView
+from .views import (
+    LogListView, MigrateSubscriptionListView, RetrySubscriptionView)
 
 urlpatterns = [
     url(
@@ -8,4 +9,7 @@ urlpatterns = [
     url(
         r'^migrations/(?P<migration_id>\d+)/logs/$', LogListView.as_view(),
         name='log-list'),
+    url(
+        r'^migrations/(?P<migration_id>\d+)/retry/$',
+        RetrySubscriptionView.as_view(), name='migration-retry'),
 ]


### PR DESCRIPTION
This PR firstly allows tasks to be resumed, without taking action on any identities that have already been processed.

Then, it also adds a button and relevant view to be able to retry any task that has errored