### PR TITLE
Add subscription migration logic

### DIFF
--- a/mapper/sequence_mapper.py
+++ b/mapper/sequence_mapper.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+
+class SequenceMapper(object):
+    """
+    Provides the logic for mapping the sequence number from one message set to
+    another.
+    """
+    def map(self, from_messageset, to_messageset, sequence):
+        # Default to no mapping
+        return sequence
+
+map_sequence = SequenceMapper().map

--- a/mapper/sequence_mapper.py
+++ b/mapper/sequence_mapper.py
@@ -11,4 +11,5 @@ class SequenceMapper(object):
         # Default to no mapping
         return sequence
 
+
 map_sequence = SequenceMapper().map

--- a/mapper/urls.py
+++ b/mapper/urls.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, unicode_literals
+
 from django.conf.urls import url
 
 from .views import (


### PR DESCRIPTION
This PR is concerned with adding the logic to migrate an identity between the specified messagesets.