### PR TITLE
Add mapping for testing messagesets

### DIFF
--- a/mapper/sequence_mapper.py
+++ b/mapper/sequence_mapper.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from math import ceil
 
 
 class NoMappingFound(Exception):
@@ -13,12 +14,27 @@ class SequenceMapper(object):
     """
     Provides the logic for mapping from one message set to another.
     """
+    def map_test_messageset_1(self, sequence):
+        """
+        Maps from the first testing messageset to the second testing
+        messageset.
+        """
+        return 'test.messageset.2', 9 + 2 * sequence
+
+    def map_test_messageset_2(self, sequence):
+        """
+        Maps from the second testing messageset back to the first.
+        """
+        return 'test.messageset.1', max(0, int(ceil((sequence - 9) / 2.0)))
+
     def map_forward(self, messageset, sequence):
         """
         Given the short_name of the messageset, and the current sequence number
         returns the tuple (messageset, sequence) of the mapped messageset and
         sequence.
         """
+        if messageset == 'test.messageset.1':
+            return self.map_test_messageset_1(sequence)
         # If we cannot find any mapping, raise the exception
         raise NoMappingFound(
             "No mapping can be found for messageset {messageset} and sequence "
@@ -30,6 +46,8 @@ class SequenceMapper(object):
         returns the tuple (messageset, sequence) of the mapped messageset and
         sequence.
         """
+        if messageset == 'test.messageset.2':
+            return self.map_test_messageset_2(sequence)
         # If we cannot find any mapping, raise the exception
         raise NoMappingFound(
             "No mapping can be found for messageset {messageset} and sequence "

--- a/mapper/sequence_mapper.py
+++ b/mapper/sequence_mapper.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-from math import ceil
+from math import floor
 
 
 class NoMappingFound(Exception):
@@ -19,13 +19,13 @@ class SequenceMapper(object):
         Maps from the first testing messageset to the second testing
         messageset.
         """
-        return 'test.messageset.2', 9 + 2 * sequence
+        return 'test.messageset.2', max(0, 2 * sequence - 1)
 
     def map_test_messageset_2(self, sequence):
         """
         Maps from the second testing messageset back to the first.
         """
-        return 'test.messageset.1', max(0, int(ceil((sequence - 9) / 2.0)))
+        return 'test.messageset.1', int(floor(sequence / 2.0) + 1)
 
     def map_forward(self, messageset, sequence):
         """

--- a/mapper/tests/test_sequence_mapper.py
+++ b/mapper/tests/test_sequence_mapper.py
@@ -13,3 +13,27 @@ class MapSubscriptionsTest(TestCase):
         """
         self.assertRaises(NoMappingFound, map_forward, None, None)
         self.assertRaises(NoMappingFound, map_backward, None, None)
+
+    def test_map_test_messageset_1(self):
+        """
+        test.messageset.1 should map forward to test.messageset.2 with an
+        offset and scale.
+        """
+        sequence_from = [1, 2, 3]
+        sequence_to = [11, 13, 15]
+        for seq_from, seq_to in zip(sequence_from, sequence_to):
+            ms, seq = map_forward('test.messageset.1', seq_from)
+            self.assertEqual(ms, 'test.messageset.2')
+            self.assertEqual(seq, seq_to)
+
+    def test_map_test_messageset_2(self):
+        """
+        test.messageset.2 should map backwards to test_messageset.1 with a
+        scale and offset.
+        """
+        sequence_from = [0, 11, 12, 13, 14]
+        sequence_to = [0, 1, 2, 2, 3]
+        for seq_from, seq_to in zip(sequence_from, sequence_to):
+            ms, seq = map_backward('test.messageset.2', seq_from)
+            self.assertEqual(ms, 'test.messageset.1')
+            self.assertEqual(seq, seq_to)

--- a/mapper/tests/test_sequence_mapper.py
+++ b/mapper/tests/test_sequence_mapper.py
@@ -16,11 +16,10 @@ class MapSubscriptionsTest(TestCase):
 
     def test_map_test_messageset_1(self):
         """
-        test.messageset.1 should map forward to test.messageset.2 with an
-        offset and scale.
+        test.messageset.1 should map forward to test.messageset.2 with a scale.
         """
-        sequence_from = [1, 2, 3]
-        sequence_to = [11, 13, 15]
+        sequence_from = [0, 1, 2, 3]
+        sequence_to = [0, 1, 3, 5]
         for seq_from, seq_to in zip(sequence_from, sequence_to):
             ms, seq = map_forward('test.messageset.1', seq_from)
             self.assertEqual(ms, 'test.messageset.2')
@@ -29,10 +28,10 @@ class MapSubscriptionsTest(TestCase):
     def test_map_test_messageset_2(self):
         """
         test.messageset.2 should map backwards to test_messageset.1 with a
-        scale and offset.
+        scale.
         """
-        sequence_from = [0, 11, 12, 13, 14]
-        sequence_to = [0, 1, 2, 2, 3]
+        sequence_from = [1, 2, 3, 4, 5]
+        sequence_to = [1, 2, 2, 3, 3]
         for seq_from, seq_to in zip(sequence_from, sequence_to):
             ms, seq = map_backward('test.messageset.2', seq_from)
             self.assertEqual(ms, 'test.messageset.1')


### PR DESCRIPTION
In order to test that the system works correctly, we need to define a forward and backward mapping between two testing messagesets.