### PR TITLE
Change test messageset names to include gates

### DIFF
--- a/mapper/sequence_mapper.py
+++ b/mapper/sequence_mapper.py
@@ -19,13 +19,13 @@ class SequenceMapper(object):
         Maps from the first testing messageset to the second testing
         messageset.
         """
-        return 'test.messageset.2', max(0, 2 * sequence - 1)
+        return 'test.gates.messageset.2', max(0, 2 * sequence - 1)
 
     def map_test_messageset_2(self, sequence):
         """
         Maps from the second testing messageset back to the first.
         """
-        return 'test.messageset.1', int(floor(sequence / 2.0) + 1)
+        return 'test.gates.messageset.1', int(floor(sequence / 2.0) + 1)
 
     def map_forward(self, messageset, sequence):
         """
@@ -33,7 +33,7 @@ class SequenceMapper(object):
         returns the tuple (messageset, sequence) of the mapped messageset and
         sequence.
         """
-        if messageset == 'test.messageset.1':
+        if messageset == 'test.gates.messageset.1':
             return self.map_test_messageset_1(sequence)
         # If we cannot find any mapping, raise the exception
         raise NoMappingFound(
@@ -46,7 +46,7 @@ class SequenceMapper(object):
         returns the tuple (messageset, sequence) of the mapped messageset and
         sequence.
         """
-        if messageset == 'test.messageset.2':
+        if messageset == 'test.gates.messageset.2':
             return self.map_test_messageset_2(sequence)
         # If we cannot find any mapping, raise the exception
         raise NoMappingFound(

--- a/mapper/tests/test_sequence_mapper.py
+++ b/mapper/tests/test_sequence_mapper.py
@@ -14,25 +14,26 @@ class MapSubscriptionsTest(TestCase):
         self.assertRaises(NoMappingFound, map_forward, None, None)
         self.assertRaises(NoMappingFound, map_backward, None, None)
 
-    def test_map_test_messageset_1(self):
+    def test_map_test_gates_messageset_1(self):
         """
-        test.messageset.1 should map forward to test.messageset.2 with a scale.
+        test.gates.messageset.1 should map forward to test.gates.messageset.2
+        with a scale.
         """
         sequence_from = [0, 1, 2, 3]
         sequence_to = [0, 1, 3, 5]
         for seq_from, seq_to in zip(sequence_from, sequence_to):
-            ms, seq = map_forward('test.messageset.1', seq_from)
-            self.assertEqual(ms, 'test.messageset.2')
+            ms, seq = map_forward('test.gates.messageset.1', seq_from)
+            self.assertEqual(ms, 'test.gates.messageset.2')
             self.assertEqual(seq, seq_to)
 
-    def test_map_test_messageset_2(self):
+    def test_map_test_gates_messageset_2(self):
         """
-        test.messageset.2 should map backwards to test_messageset.1 with a
-        scale.
+        test.gates.messageset.2 should map backwards to test.gates.messageset.1
+        with a scale.
         """
         sequence_from = [1, 2, 3, 4, 5]
         sequence_to = [1, 2, 2, 3, 3]
         for seq_from, seq_to in zip(sequence_from, sequence_to):
-            ms, seq = map_backward('test.messageset.2', seq_from)
-            self.assertEqual(ms, 'test.messageset.1')
+            ms, seq = map_backward('test.gates.messageset.2', seq_from)
+            self.assertEqual(ms, 'test.gates.messageset.1')
             self.assertEqual(seq, seq_to)


### PR DESCRIPTION
Currently, our test messageset names don't include the word "gates". So when testing the opting out section of the code, it skips over our test messagesets, because it doesn't include "gates", and so we cannot complete the optout. This PR changes our test messageset names to include "gates".